### PR TITLE
Preserve the permissions bits

### DIFF
--- a/src/pyc_wheel/_pyc_wheel.py
+++ b/src/pyc_wheel/_pyc_wheel.py
@@ -78,6 +78,11 @@ def convert_wheel(whl_file: Path, *, exclude=None, with_backup=False, quiet=Fals
                 os.utime(str(file_path), (timestamp, timestamp))
             except Exception:
                 pass  # ignore errors
+            permission_bits = (member.external_attr >> 16) & 0o777
+            try:
+                os.chmod(str(file_path), permission_bits)
+            except Exception:
+                pass  # ignore errors
 
         dist_info_path = whl_path/"{}.dist-info".format(dist_info)
         rewrite_dist_info(dist_info_path, exclude=exclude)


### PR DESCRIPTION
Fixes #5
Apply the permission bits from the .whl zip file to the unpacked copy causes the execute permission to be preserved on scripts