### PR TITLE
Adding support for Python 3.12

### DIFF
--- a/src/pyc_wheel/_pyc_wheel.py
+++ b/src/pyc_wheel/_pyc_wheel.py
@@ -7,6 +7,7 @@
 
 import sys
 import os
+import setuptools
 import distutils
 import re
 import stat


### PR DESCRIPTION
* As ``distutils`` moved to ``setuptools`` it is required to import ``setuptools``